### PR TITLE
[Fix] 비동기 exception 처리하기 #72

### DIFF
--- a/src/domain/queue/queue.service.ts
+++ b/src/domain/queue/queue.service.ts
@@ -25,8 +25,8 @@ export class QueueService {
     const { userId, mode, type } = postDto;
     const mutex: Mutex = this.mutexManager.getMutex('queue');
     const release = await mutex.acquire();
-    this.checkUserInQueue(userId, release);
-    this.checkUserIsInGame(userId, release);
+    await this.checkUserInQueue(userId, release);
+    await this.checkUserIsInGame(userId, release);
 
     try {
       await this.redisUserRepository.setUserInfo(userId);
@@ -86,7 +86,10 @@ export class QueueService {
     }
   }
 
-  private checkUserInQueue(userId: number, release: () => void): void {
+  private async checkUserInQueue(
+    userId: number,
+    release: () => void,
+  ): Promise<void> {
     if (this.queueFactory.isIn(userId)) {
       release();
       throw new BadRequestException('Already in queue');


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#72 
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- async 함수 안에서 exception 던질때 await로 안잡아주면 서버가 죽는 문제가 있었음..
- await 붙여서 해결..

