### PR TITLE
[Fix] 게임 렉 개선하기 #82

### DIFF
--- a/src/domain/factory/model/game.model.ts
+++ b/src/domain/factory/model/game.model.ts
@@ -26,6 +26,7 @@ export class GameModel {
   status: 'standby' | 'playing' | 'end';
   touchLog: GameLog[];
   pastBallPosition: { x: number; y: number }[];
+  frame: number;
 
   constructor(
     player1: UserModel,
@@ -49,5 +50,6 @@ export class GameModel {
     this.status = 'standby';
     this.touchLog = [];
     this.pastBallPosition = [];
+    this.frame = 0;
   }
 }

--- a/src/domain/factory/objects/ball.ts
+++ b/src/domain/factory/objects/ball.ts
@@ -53,7 +53,7 @@ export class Ball {
   reset(direction: number): void {
     this.x = +process.env.BOARD_WIDTH / 2;
     this.y = +process.env.BOARD_HEIGHT / 2;
-    this.direction = new Vector(-randomInt(0, 5), direction * randomInt(5, 10));
+    this.direction = new Vector(0, direction);
     this.direction = this.direction.normalize();
     this.spinSpeed = 0;
     this.speed = this.beginSpeed;

--- a/src/domain/factory/objects/ball.ts
+++ b/src/domain/factory/objects/ball.ts
@@ -77,7 +77,31 @@ export class Ball {
   touchWall(): void {
     this.direction.x *= -1;
     this.spinSpeed *= this.elasticity;
-    // process.stdout.write('\u0007');
+    if (this.x < this.size / 2) {
+      this.setPosition(this.size / 2, this.y);
+    }
+    if (this.x > +process.env.BOARD_WIDTH - this.size / 2) {
+      this.setPosition(+process.env.BOARD_WIDTH - this.size / 2, this.y);
+    }
+  }
+
+  isTouchingBar(bar: Bar): boolean {
+    const barLeft: number = bar.position - bar.width / 2;
+    const barRight: number = bar.position + bar.width / 2;
+
+    // 위쪽과 아래쪽을 체크
+    if (bar.isReverse)
+      return (
+        this.y - this.size / 2 <= 1.5 / +process.env.BOARD_HEIGHT &&
+        this.x + this.size >= barLeft &&
+        this.x - this.size <= barRight
+      );
+    return (
+      this.y + this.size / 2 >=
+        +process.env.BOARD_HEIGHT - 1.5 / +process.env.BOARD_HEIGHT &&
+      this.x + this.size >= barLeft &&
+      this.x - this.size <= barRight
+    );
   }
 
   touchBar(bar: Bar): void {
@@ -104,6 +128,11 @@ export class Ball {
     this.speed *= this.elasticity * bar.elasticity;
     if (this.speed > +process.env.BALL_SPEED * 5)
       this.speed = +process.env.BALL_SPEED * 5;
+    if (this.y > +process.env.BOARD_HEIGHT - this.size / 2) {
+      this.setPosition(this.x, +process.env.BOARD_HEIGHT - this.size / 2);
+    } else if (this.y < this.size / 2) {
+      this.setPosition(this.x, this.size / 2);
+    }
   }
 
   randomBounce(): void {
@@ -117,6 +146,16 @@ export class Ball {
   }
 
   saveLog(): Ball {
+    const ball = new Ball(this.size, this.speed);
+    ball.x = this.x;
+    ball.y = this.y;
+    ball.direction = this.direction;
+    ball.spinSpeed = this.spinSpeed;
+    ball.elasticity = this.elasticity;
+    return ball;
+  }
+
+  copy(): Ball {
     const ball = new Ball(this.size, this.speed);
     ball.x = this.x;
     ball.y = this.y;

--- a/src/domain/factory/objects/bar.ts
+++ b/src/domain/factory/objects/bar.ts
@@ -72,4 +72,17 @@ export class Bar {
       return;
     }
   }
+
+  copy(): Bar {
+    const bar: Bar = new Bar(
+      this.speed,
+      this.width,
+      this.position,
+      this.isReverse,
+    );
+    bar.direction = this.direction;
+    bar.movedDistance = this.movedDistance;
+    bar.mode = this.mode;
+    return bar;
+  }
 }

--- a/src/domain/game/dto/game.pos.update.dto.ts
+++ b/src/domain/game/dto/game.pos.update.dto.ts
@@ -1,37 +1,83 @@
 import { GameModel } from 'src/domain/factory/model/game.model';
 import * as dotenv from 'dotenv';
+import { Ball } from 'src/domain/factory/objects/ball';
+import { Bar } from 'src/domain/factory/objects/bar';
 
 dotenv.config();
 
-export class GamePosUpdateDto {
+class GamePosDto {
   ballPos: { x: number; y: number };
   playerXPos: {
     me: number;
     opponent: number;
   };
   gameTime: number;
+  frame: number;
+
+  constructor(
+    ballPos: { x: number; y: number },
+    playerXPos: {
+      me: number;
+      opponent: number;
+    },
+    gameTime: number,
+    frame: number,
+  ) {
+    this.ballPos = ballPos;
+    this.playerXPos = playerXPos;
+    this.gameTime = gameTime;
+    this.frame = frame;
+  }
+}
+
+export class GamePosUpdateDto {
+  data: GamePosDto[] = [];
 
   constructor(game: GameModel, userId: number) {
-    if (game.player1.id === userId) {
-      this.ballPos = {
-        x: game.ball.x / game.board.width,
-        y: game.ball.y / game.board.height,
-      };
-      this.playerXPos = {
-        me: game.player1.bar.position / game.board.width,
-        opponent: game.player2.bar.position / game.board.width,
-      };
-    } else {
-      this.ballPos = {
-        x: (game.board.width - game.ball.x) / game.board.width,
-        y: (game.board.height - game.ball.y) / game.board.height,
-      };
-      this.playerXPos = {
-        me: (game.board.width - game.player2.bar.position) / game.board.width,
-        opponent:
-          (game.board.width - game.player1.bar.position) / game.board.width,
-      };
+    const tempBall: Ball = game.ball.copy();
+    const tempPlayer1Bar: Bar = game.player1.bar.copy();
+    const tempPlayer2Bar: Bar = game.player2.bar.copy();
+
+    for (let i = 0; i < 20; i++) {
+      const gameTime =
+        +process.env.GAME_TIME -
+        (game.playTime + (i * 1000) / +process.env.GAME_FRAME);
+      if (game.player1.id === userId) {
+        const ballPos = {
+          x: tempBall.x / game.board.width,
+          y: tempBall.y / game.board.height,
+        };
+        const playerXPos = {
+          me: tempPlayer1Bar.position / game.board.width,
+          opponent: tempPlayer2Bar.position / game.board.width,
+        };
+        this.data.push(
+          new GamePosDto(ballPos, playerXPos, gameTime, game.frame + i),
+        );
+      } else {
+        const ballPos = {
+          x: (game.board.width - tempBall.x) / game.board.width,
+          y: (game.board.height - tempBall.y) / game.board.height,
+        };
+        const playerXPos = {
+          me: (game.board.width - tempPlayer2Bar.position) / game.board.width,
+          opponent:
+            (game.board.width - tempPlayer1Bar.position) / game.board.width,
+        };
+        this.data.push(
+          new GamePosDto(ballPos, playerXPos, gameTime, game.frame + i),
+        );
+      }
+      tempBall.move();
+      tempPlayer1Bar.move();
+      tempPlayer2Bar.move();
+      if (tempBall.x - tempBall.size / 2 <= 0) tempBall.touchWall();
+      if (tempBall.x + tempBall.size / 2 >= game.board.width)
+        tempBall.touchWall();
+      if (tempBall.isTouchingBar(tempPlayer1Bar))
+        tempBall.touchBar(tempPlayer1Bar);
+      if (tempBall.isTouchingBar(tempPlayer2Bar))
+        tempBall.touchBar(tempPlayer2Bar);
     }
-    this.gameTime = +process.env.GAME_TIME - game.playTime;
   }
 }

--- a/src/domain/game/dto/game.pos.update.dto.ts
+++ b/src/domain/game/dto/game.pos.update.dto.ts
@@ -38,7 +38,7 @@ export class GamePosUpdateDto {
     const tempPlayer1Bar: Bar = game.player1.bar.copy();
     const tempPlayer2Bar: Bar = game.player2.bar.copy();
 
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       const gameTime =
         +process.env.GAME_TIME -
         (game.playTime + (i * 1000) / +process.env.GAME_FRAME);

--- a/src/domain/game/game.service.ts
+++ b/src/domain/game/game.service.ts
@@ -57,7 +57,6 @@ export class GameService {
 
   @Cron('0/10 * * * * *')
   async cleanUpUnmatchedGames(): Promise<void> {
-    console.log('matching...');
     this.gameFactory.games.forEach(async (game) => {
       if (
         game.status === 'standby' &&

--- a/src/domain/gateway/game.gateway.ts
+++ b/src/domain/gateway/game.gateway.ts
@@ -326,9 +326,15 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     game.player2.socket?.emit('wallTouch', {});
   }
 
-  async sendTouchBarEvent(game: GameModel): Promise<void> {
-    game.player1.socket?.emit('barTouch', {});
-    game.player2.socket?.emit('barTouch', {});
+  async sendTouchBarEvent(bar: Bar, game: GameModel): Promise<void> {
+    if (bar.movedDistance !== 0) {
+      game.player1.socket?.emit('spin', {});
+      game.player2.socket?.emit('spin', {});
+      return;
+    } else {
+      game.player1.socket?.emit('barTouch', {});
+      game.player2.socket?.emit('barTouch', {});
+    }
   }
 
   sendPositionUpdate(game: GameModel): void {
@@ -473,6 +479,6 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     if (game.mode === GAMEMODE_RANDOMBOUNCE) {
       ball.randomBounce();
     }
-    this.sendTouchBarEvent(game);
+    this.sendTouchBarEvent(bar, game);
   }
 }

--- a/src/domain/gateway/game.gateway.ts
+++ b/src/domain/gateway/game.gateway.ts
@@ -224,10 +224,11 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
       return;
     }
     this.move(game);
-    await this.handleTouchEvent(game);
-    await this.sendPositionUpdate(game);
+    this.handleTouchEvent(game);
+    if (game.frame % 2 === 0) this.sendPositionUpdate(game);
     await this.handleGoal(game, game.ball);
     this.setPlayTime(game);
+    game.frame++;
     setTimeout(() => {
       this.gameLoop(game);
     }, 1000 / +process.env.GAME_FRAME);
@@ -244,62 +245,29 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     game.player2.bar.move();
   }
 
-  async handleTouchEvent(game: GameModel): Promise<void> {
-    await this.handleTouchBar(game, game.player1, game.ball);
-    await this.handleTouchBar(game, game.player2, game.ball);
-    await this.handleTouchWall(game, game.ball);
+  handleTouchEvent(game: GameModel): void {
+    this.handleTouchBar(game, game.player1, game.ball);
+    this.handleTouchBar(game, game.player2, game.ball);
+    this.handleTouchWall(game, game.ball);
   }
 
-  async handleTouchBar(
-    game: GameModel,
-    player: GamePlayerModel,
-    ball: Ball,
-  ): Promise<void> {
-    const bar: Bar = player.bar;
-
+  handleTouchBar(game: GameModel, player: GamePlayerModel, ball: Ball): void {
     // user2 바 체크
-    if (
-      player.id === game.player2.id &&
-      (await this.isBallTouchingBar(ball, bar, 1.5 / +process.env.BOARD_HEIGHT))
-    ) {
-      await this.handleBallTouchingBar(
-        game,
-        ball,
-        player,
-        1.5 / game.board.height + ball.size / 2,
-      );
-    }
-
-    //  user1 바 체크
-    if (
-      player.id === game.player1.id &&
-      (await this.isBallTouchingBar(
-        ball,
-        bar,
-        game.board.height - 1.5 / game.board.height,
-      ))
-    ) {
-      await this.handleBallTouchingBar(
-        game,
-        ball,
-        player,
-        game.board.height - 1.5 / game.board.height - ball.size / 2,
-      );
+    if (ball.isTouchingBar(player.bar)) {
+      this.handleBallTouchingBar(game, ball, player);
     }
   }
 
-  async handleTouchWall(game: GameModel, ball: Ball): Promise<void> {
+  handleTouchWall(game: GameModel, ball: Ball): void {
     // 왼쪽 벽 체크
     if (ball.x - ball.size / 2 <= 0) {
       ball.touchWall();
-      ball.setPosition(ball.size / 2, ball.y);
-      await this.sendTouchWallEvent(game);
+      this.sendTouchWallEvent(game);
     }
     // 오른쪽 벽 체크
     if (ball.x + ball.size / 2 >= game.board.width) {
       ball.touchWall();
-      ball.setPosition(game.board.width - ball.size / 2, ball.y);
-      await this.sendTouchWallEvent(game);
+      this.sendTouchWallEvent(game);
     }
   }
 
@@ -325,7 +293,7 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
       game.round++;
       this.sendRoundUpdate(game);
     }
-    if (await this.checkGameEnd(game)) {
+    if (this.checkGameEnd(game)) {
       await this.endGame(game);
       return;
     }
@@ -335,7 +303,7 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     }
   }
 
-  async checkGameEnd(game: GameModel): Promise<boolean> {
+  checkGameEnd(game: GameModel): boolean {
     return (
       game.player1.score === +process.env.GAME_FINISH_SCORE ||
       game.player2.score === +process.env.GAME_FINISH_SCORE ||
@@ -353,7 +321,7 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     game.status = 'playing';
   }
 
-  async sendTouchWallEvent(game: GameModel): Promise<void> {
+  sendTouchWallEvent(game: GameModel): void {
     game.player1.socket?.emit('wallTouch', {});
     game.player2.socket?.emit('wallTouch', {});
   }
@@ -363,7 +331,7 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     game.player2.socket?.emit('barTouch', {});
   }
 
-  async sendPositionUpdate(game: GameModel): Promise<void> {
+  sendPositionUpdate(game: GameModel): void {
     game.player1.socket?.emit(
       'posUpdate',
       new GamePosUpdateDto(game, game.player1.id),
@@ -475,41 +443,36 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     });
   }
 
-  private async isBallTouchingBar(
-    ball: Ball,
-    bar: Bar,
-    yPosition: number,
-  ): Promise<boolean> {
+  private isBallTouchingBar(ball: Ball, bar: Bar): boolean {
     const barLeft: number = bar.position - bar.width / 2;
     const barRight: number = bar.position + bar.width / 2;
 
     // 위쪽과 아래쪽을 체크
-    if (yPosition === 1.5 / +process.env.BOARD_HEIGHT)
+    if (bar.isReverse)
       return (
-        ball.y - ball.size / 2 <= yPosition &&
+        ball.y - ball.size / 2 <= 1.5 / +process.env.BOARD_HEIGHT &&
         ball.x + ball.size >= barLeft &&
         ball.x - ball.size <= barRight
       );
     return (
-      ball.y + ball.size / 2 >= yPosition &&
+      ball.y + ball.size / 2 >=
+        +process.env.BOARD_HEIGHT - 1.5 / +process.env.BOARD_HEIGHT &&
       ball.x + ball.size >= barLeft &&
       ball.x - ball.size <= barRight
     );
   }
 
-  private async handleBallTouchingBar(
+  private handleBallTouchingBar(
     game: GameModel,
     ball: Ball,
     player: GamePlayerModel,
-    yPosition: number,
-  ): Promise<void> {
+  ): void {
     const bar: Bar = player.bar;
     game.touchLog.push(new GameLog(player.id, game.round, 'touch', ball));
     ball.touchBar(bar);
     if (game.mode === GAMEMODE_RANDOMBOUNCE) {
       ball.randomBounce();
     }
-    ball.setPosition(ball.x, yPosition);
-    await this.sendTouchBarEvent(game);
+    this.sendTouchBarEvent(game);
   }
 }

--- a/src/domain/queue/queue.service.ts
+++ b/src/domain/queue/queue.service.ts
@@ -58,7 +58,6 @@ export class QueueService {
     const mutex: Mutex = this.mutexManager.getMutex('queue');
     const release = await mutex.acquire();
     try {
-      console.log('matching...');
       await this.processNormalQueue();
       await this.processLadderQueue();
     } finally {

--- a/src/domain/user/user.entity.ts
+++ b/src/domain/user/user.entity.ts
@@ -8,7 +8,4 @@ export class User extends BaseTimeEntity {
 
   @Column({ name: 'nickname' })
   nickname: string;
-
-  @Column({ name: 'ladder_point' })
-  ladderPoint: number;
 }

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { UserFactory } from '../factory/user.factory';
 import {
   IsolationLevel,
   Transactional,


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
- #82 
- #84 
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 서버-클라이언트가 서로 다른 네트워크를 사용하는 경우 게임 렉이 심해서 개선 작업을 진행했습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
### issue 82
- 네트워크 딜레이 보완 로직
    - 게임 진행시 `sendPosUpdate()` 함수에서 미래의 프레임 10개를 같이 보냅니다
    - 클라이언트에서 정보를 받지 못했을 경우 받아놓은 미래의 프레임을 그려주고, 받은 경우 받은 프레임을 그려줄 것입니다
    - 게임마다 frame 변수를 추가해 프레임별 위치 정보와 함께 전송합니다. frame 변수는 공의 잔상을 표현하는데 사용됩니다.
    - 게임 로직 내에서 성능 저하를 가져올 수 있는 `async` - `await` 구문을 최대한 삭제했습니다. `sleep()`을 호출해야 하는 `handleGoal()`을 제외하고는 동기로 처리되도록 수정했습니다.
- 로직 처리 부분 수정
    - GameGateWay에서 판별하던 공의 충돌 로직들을 Ball 클래스 내부로 이동했습니다.

### issue 84 
- 공이 움직이는 바에 맞을 때 event를 다르게 보내주도록 수정했습니다
    - 정지된 바 : `barTouch`
    - 움직이는 바 : `spin`

## 변경 뒤 게임 화면
https://github.com/Dr-Pong/dr_pong_game_server/assets/90181905/b5faaa1b-b42e-43fb-a580-1cfa5991f220
