### PR TITLE
[Feat] 랜덤 시드 생성해서 계산하는 코드 추가 #91

### DIFF
--- a/src/domain/factory/model/game.model.ts
+++ b/src/domain/factory/model/game.model.ts
@@ -1,4 +1,7 @@
-import { GameMode } from 'src/global/type/type.game.mode';
+import {
+  GAMEMODE_RANDOMBOUNCE,
+  GameMode,
+} from 'src/global/type/type.game.mode';
 import { v4 as uuid } from 'uuid';
 import { GameBoard } from '../objects/game-board';
 import { Ball } from '../objects/ball';
@@ -7,6 +10,7 @@ import { UserModel } from './user.model';
 import { GameLog } from './game.log';
 import { GameType } from 'src/global/type/type.game.type';
 import * as dotenv from 'dotenv';
+import { randomInt } from 'crypto';
 
 dotenv.config();
 
@@ -26,6 +30,8 @@ export class GameModel {
   status: 'standby' | 'playing' | 'end';
   touchLog: GameLog[];
   pastBallPosition: { x: number; y: number }[];
+  randomSeed: number[];
+  seedIndex: number;
   frame: number;
 
   constructor(
@@ -37,6 +43,13 @@ export class GameModel {
     this.id = uuid();
     this.type = type;
     this.mode = mode;
+    if (mode === GAMEMODE_RANDOMBOUNCE) {
+      this.randomSeed = [];
+      for (let i = 0; i < 1000; i++) {
+        this.randomSeed.push(randomInt(-5, 5));
+      }
+    }
+    this.seedIndex = 0;
     this.playTime = 0;
     this.player1 = new GamePlayerModel(player1, false);
     this.player2 = new GamePlayerModel(player2, true);

--- a/src/domain/factory/objects/ball.ts
+++ b/src/domain/factory/objects/ball.ts
@@ -135,8 +135,8 @@ export class Ball {
     }
   }
 
-  randomBounce(): void {
-    this.direction.x = new Vector(randomInt(-5, 5), 1).normalize().x;
+  randomBounce(vector: number): void {
+    this.direction.x = new Vector(vector, 1).normalize().x;
     this.direction.normalize();
   }
 

--- a/src/domain/game/dto/game.pos.update.dto.ts
+++ b/src/domain/game/dto/game.pos.update.dto.ts
@@ -2,6 +2,7 @@ import { GameModel } from 'src/domain/factory/model/game.model';
 import * as dotenv from 'dotenv';
 import { Ball } from 'src/domain/factory/objects/ball';
 import { Bar } from 'src/domain/factory/objects/bar';
+import { GAMEMODE_RANDOMBOUNCE } from 'src/global/type/type.game.mode';
 
 dotenv.config();
 
@@ -74,10 +75,16 @@ export class GamePosUpdateDto {
       if (tempBall.x - tempBall.size / 2 <= 0) tempBall.touchWall();
       if (tempBall.x + tempBall.size / 2 >= game.board.width)
         tempBall.touchWall();
-      if (tempBall.isTouchingBar(tempPlayer1Bar))
+      if (tempBall.isTouchingBar(tempPlayer1Bar)) {
+        if (game.mode === GAMEMODE_RANDOMBOUNCE)
+          tempBall.randomBounce(game.randomSeed[game.seedIndex + i]);
         tempBall.touchBar(tempPlayer1Bar);
-      if (tempBall.isTouchingBar(tempPlayer2Bar))
+      }
+      if (tempBall.isTouchingBar(tempPlayer2Bar)) {
+        if (game.mode === GAMEMODE_RANDOMBOUNCE)
+          tempBall.randomBounce(game.randomSeed[game.seedIndex + i]);
         tempBall.touchBar(tempPlayer2Bar);
+      }
     }
   }
 }

--- a/src/domain/gateway/game.gateway.ts
+++ b/src/domain/gateway/game.gateway.ts
@@ -477,7 +477,8 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     game.touchLog.push(new GameLog(player.id, game.round, 'touch', ball));
     ball.touchBar(bar);
     if (game.mode === GAMEMODE_RANDOMBOUNCE) {
-      ball.randomBounce();
+      ball.randomBounce(game.randomSeed[game.seedIndex]);
+      game.seedIndex++;
     }
     this.sendTouchBarEvent(bar, game);
   }


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#91 
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 네트워크 지연을 대비해서 미리 프레임을 보내줄 때 randomBounce를 처리 못하는 문제 수정

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- GameModel 내부에 randomSeed와 seedIndex를 추가해주었습니다.
- 1000개의 랜덤한 시드값을 생성해놓은 뒤 바에 맞을 때마다 시드값으로 계산해주는 코드를 적용했습니다.
- 미리 프레임을 보내줄 때도 해당 시드값을 가지고 계산해서 보내줍니다.
