### PR TITLE
[Fix] 게임이 여러 개 생성되는 버그 수정 #95

### DIFF
--- a/src/domain/gateway/game.gateway.ts
+++ b/src/domain/gateway/game.gateway.ts
@@ -457,7 +457,7 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     game.touchLog.push(new GameLog(player.id, game.round, 'touch', ball));
     ball.touchBar(bar);
     if (game.mode === GAMEMODE_RANDOMBOUNCE) {
-      ball.randomBounce(game.randomSeed[game.seedIndex]);
+      ball.randomBounce(game.randomSeed[game.seedIndex % 300]);
       game.seedIndex++;
     }
     this.sendTouchBarEvent(bar, game);

--- a/src/domain/gateway/game.gateway.ts
+++ b/src/domain/gateway/game.gateway.ts
@@ -32,7 +32,7 @@ import { RedisUserRepository } from '../redis/redis.user.repository';
 import { MutexManager } from '../mutex/mutex.manager';
 
 @WebSocketGateway({ namespace: 'game' })
-export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
+export class GameGateWay implements OnGatewayConnection {
   constructor(
     private readonly gameFactory: GameFactory,
     private readonly mutexManager: MutexManager,
@@ -57,10 +57,6 @@ export class GameGateWay implements OnGatewayConnection, OnGatewayDisconnect {
     } finally {
       release();
     }
-  }
-
-  handleDisconnect(@ConnectedSocket() socket: Socket) {
-    // console.log('disconnect', socket.id);
   }
 
   @SubscribeMessage('keyPress')

--- a/src/domain/gateway/queue.gateway.ts
+++ b/src/domain/gateway/queue.gateway.ts
@@ -32,12 +32,10 @@ export class QueueGateWay implements OnGatewayConnection, OnGatewayDisconnect {
         this.redisUserRepository,
       );
       if (!user) {
-        console.log('user not found');
         socket.disconnect();
         release();
         return;
       }
-      console.log('join queue', user.nickname);
 
       if (user.queueSocket && user.queueSocket !== socket.id) {
         this.server.in(user.queueSocket).disconnectSockets(true);
@@ -56,7 +54,6 @@ export class QueueGateWay implements OnGatewayConnection, OnGatewayDisconnect {
       this.redisUserRepository,
     );
     if (!user) {
-      console.log('user not found');
       socket.disconnect();
       return;
     }

--- a/src/global/utils/socket.utils.ts
+++ b/src/global/utils/socket.utils.ts
@@ -23,7 +23,6 @@ export async function getUserFromSocket(
 
   const accesstoken = socket.handshake.auth?.Authorization?.split(' ')[1];
   if (!accesstoken) {
-    console.log('no token', socket.id);
     return null;
   }
   try {
@@ -32,7 +31,6 @@ export async function getUserFromSocket(
     const user: UserModel = await redisUserRepository.findById(userId);
     return user;
   } catch (e) {
-    console.log(accesstoken, e);
     return null;
   }
 }
@@ -47,27 +45,21 @@ export async function checkAchievementAndTitle(game: GameModel): Promise<void> {
       )
     ).data;
     for (const title of result?.title) {
-      console.log('title to player');
       if (title.userId === game.player1.id) {
-        console.log('player1 title');
         game.player1.socket?.emit('title', { title: title.title });
       }
       if (title.userId === game.player2.id) {
-        console.log('player2 title');
         game.player2.socket?.emit('title', { title: title.title });
       }
     }
     for (const achievement of result?.achievement) {
-      console.log('achievement to player');
       if (achievement.userId === game.player1.id) {
-        console.log('player1');
         game.player1.socket?.emit('achievement', {
           name: achievement.achievement,
           imgUrl: achievement.imgUrl,
         });
       }
       if (achievement.userId === game.player2.id) {
-        console.log('player2');
         game.player2.socket?.emit('achievement', {
           achievement: achievement.achievement,
           imgUrl: achievement.imgUrl,


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#95 
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 유저가 게임에 입장시 새로고침을 연타하면 서버 내에서 게임이 중복으로 생성되는 문제를 해결했습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- GameGateWay의 validateGameId()의 아래 코드에서 게임 처리를 담당했습니다.
```
  @SubscribeMessage('joinGame')
  async validateGameId(
    @ConnectedSocket() socket: Socket,
    @MessageBody() data: { roomId: string },
  ): Promise<void> {
    const user: UserModel = await getUserFromSocket(
      socket,
      this.redisUserRepository,
    );
    if (!user || user.gameId !== data?.roomId) {
      socket?.emit('invalidGameId', {});
      socket.disconnect();
      return;
    }
    const game: GameModel = this.gameFactory.findById(user.gameId);
    await patchUserStatesInGame(game, user);
    this.setUserIsReady(user.id, user.gameId, true);
    await this.setUserInGame(user, socket);
  }
```
- await this.setUserInGame(user, socket); 안에서
```
if (game.status === 'standby') {
        this.start(game);
}
```
라는 조건식을 통해 게임을 시작해 주었는데, `this.start(game);`은 async 함수라 여러 개의 joinGame 소켓 이벤트를 받았을 시 함수가 병렬적으로 처리되어 게임이 여러 개가 생성될 수 있다는 문제를 발견했습니다.

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->
- 해당 로직을 Mutex로 감싸 game의 state를 침범하지 않도록 설정했습니다.
